### PR TITLE
Fix path to Glade.pm6 in META6

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -15,7 +15,7 @@
     "Gnome::Gtk3::Glade::Engine": "lib/Gnome/Gtk3/Glade/Engine.pm6",
 
     "Gnome::Gtk3::Glade::X": "lib/Gnome/Gtk3/Glade/X.pm6",
-    "Gnome::Gtk3::Glade": "lib/Gnome/Glade3.pm6"
+    "Gnome::Gtk3::Glade": "lib/Gnome/Gtk3/Glade.pm6"
   },
 
   "source-url": "git://github.com/MARTIMM/gnome-glade3.git",


### PR DESCRIPTION
Zef was complaining about a missing file, but it was just a bad path.

`Failed to open file .../perl6-gnome-glade3-0.8.5/lib/Gnome/Glade3.pm6: No such file or directory`